### PR TITLE
feat: createdb.yaml pre-install hook for db-init

### DIFF
--- a/charts/permify/Chart.yaml
+++ b/charts/permify/Chart.yaml
@@ -17,10 +17,10 @@ description: Helm charts for deploying and managing Permify in Kubernetes enviro
 type: application
 
 # The version of the Helm chart.
-version: 0.3.5
+version: 0.3.6
 
 # The specific application version that this Helm chart is designed to deploy.
-appVersion: "v0.10.0"
+appVersion: "v1.0.4"
 
 # Keywords associated with the Helm chart for searchability.
 keywords:

--- a/charts/permify/Chart.yaml
+++ b/charts/permify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 version: 0.3.6
 
 # The specific application version that this Helm chart is designed to deploy.
-appVersion: "v1.0.4"
+appVersion: "v1.1.0"
 
 # Keywords associated with the Helm chart for searchability.
 keywords:

--- a/charts/permify/templates/createdb.yaml
+++ b/charts/permify/templates/createdb.yaml
@@ -1,0 +1,49 @@
+{{- if eq .Values.app.database.engine "postgres" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "cretedb-{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 500
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      containers:
+      - name: createdb
+        image: postgres:11-alpine # A relatively small official image that can run psql
+        command:
+          - sh
+          - -c
+          - >
+              while ! pg_isready -U postgres -h ${DBHOST} -p ${DBPORT}; do sleep 1; done;
+
+              DB_EXISTS=$(psql "${DBURI}" -tAc "SELECT 1 FROM pg_database WHERE datname='${DBNAME}'")
+              
+              if [ "$DB_EXISTS" != "1" ]; then
+                psql "${DBURI}" -c "CREATE DATABASE \"${DBNAME}\""
+              fi
+        env:
+        - name: DBNAME
+          value: {{ .Values.app.database.dbname | quote }}
+        - name: DBHOST
+          value: {{ .Values.app.database.host | quote }}
+        - name: DBPORT
+          value: {{ .Values.app.database.port | quote }}
+        - name: DBURI
+          value: {{ .Values.app.database.uri | quote }}
+      restartPolicy: OnFailure
+  backoffLimit: 2
+...
+{{ end }}

--- a/charts/permify/templates/createdb.yaml
+++ b/charts/permify/templates/createdb.yaml
@@ -1,9 +1,9 @@
-{{- if eq .Values.app.database.engine "postgres" }}
+{{- if eq .Values.jobs.createDatabase.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cretedb-{{ .Release.Name }}"
+  name: "crete-database-{{ .Release.Name }}"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -21,7 +21,7 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       containers:
-      - name: createdb
+      - name: crete-database
         image: postgres:11-alpine # A relatively small official image that can run psql
         command:
           - sh
@@ -36,13 +36,13 @@ spec:
               fi
         env:
         - name: DBNAME
-          value: {{ .Values.app.database.dbname | quote }}
+          value: {{ .Values.jobs.createDatabase.name | quote }}
         - name: DBHOST
-          value: {{ .Values.app.database.host | quote }}
+          value: {{ .Values.jobs.createDatabase.host | quote }}
         - name: DBPORT
-          value: {{ .Values.app.database.port | quote }}
+          value: {{ .Values.jobs.createDatabase.port | quote }}
         - name: DBURI
-          value: {{ .Values.app.database.uri | quote }}
+          value: {{ .Values.jobs.createDatabase.uri | quote }}
       restartPolicy: OnFailure
   backoffLimit: 2
 ...

--- a/charts/permify/templates/createdb.yaml
+++ b/charts/permify/templates/createdb.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "crete-database-{{ .Release.Name }}"
+  name: "create-database-{{ .Release.Name }}"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -21,7 +21,7 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       containers:
-      - name: crete-database
+      - name: create-database
         image: postgres:11-alpine # A relatively small official image that can run psql
         command:
           - sh

--- a/charts/permify/values.yaml
+++ b/charts/permify/values.yaml
@@ -149,10 +149,10 @@ resources: {}
 
 jobs:
   createDatabase:
-    enabled: true
-    name:
-    host:
-    port:
+    enabled: false
+    name: dev
+    host: localhost
+    port: 5432
     uri: postgres://postgres:secret@localhost:5432/permify?sslmode=disable
 
 # Autoscaling configuration

--- a/charts/permify/values.yaml
+++ b/charts/permify/values.yaml
@@ -114,6 +114,9 @@ app:
     engine: memory
     # Uncomment to use PostgreSQL
     # engine: postgres
+    # host:
+    # port:
+    # dbname:
     # uri: postgres://postgres:secret@localhost:5432/permify?sslmode=disable
     # uri_secret:
     # auto_migrate: true

--- a/charts/permify/values.yaml
+++ b/charts/permify/values.yaml
@@ -114,9 +114,6 @@ app:
     engine: memory
     # Uncomment to use PostgreSQL
     # engine: postgres
-    # host:
-    # port:
-    # dbname:
     # uri: postgres://postgres:secret@localhost:5432/permify?sslmode=disable
     # uri_secret:
     # auto_migrate: true
@@ -149,6 +146,14 @@ ingress:
 
 # Resource requests and limits
 resources: {}
+
+jobs:
+  createDatabase:
+    enabled: true
+    name:
+    host:
+    port:
+    uri: postgres://postgres:secret@localhost:5432/permify?sslmode=disable
 
 # Autoscaling configuration
 autoscaling:


### PR DESCRIPTION
This PR introduces a new Helm chart pre-install hook file, createdb.yaml, which ensures that a specified PostgreSQL database is created if it does not already exist. This enhancement improves the deployment process by automating the database setup, reducing manual intervention, and ensuring consistency across environments.