### PR TITLE
Add missing backoff frequency

### DIFF
--- a/charts/permify/Chart.yaml
+++ b/charts/permify/Chart.yaml
@@ -17,7 +17,7 @@ description: Helm charts for deploying and managing Permify in Kubernetes enviro
 type: application
 
 # The version of the Helm chart.
-version: 0.3.9
+version: 0.4.0
 
 # The specific application version that this Helm chart is designed to deploy.
 appVersion: "v1.1.3"

--- a/charts/permify/templates/deployment.yaml
+++ b/charts/permify/templates/deployment.yaml
@@ -212,6 +212,11 @@ spec:
               value: "{{ .Values.app.authn.oidc.backoff_interval }}"
             {{- end }}
 
+            {{- if .Values.app.authn.oidc.backoff_frequency }}
+            - name: PERMIFY_AUTHN_OIDC_BACKOFF_FREQUENCY
+              value: "{{ .Values.app.authn.oidc.backoff_frequency }}"
+            {{- end }}
+
             {{- if .Values.app.authn.oidc.backoff_max_retries }}
             - name: PERMIFY_AUTHN_OIDC_BACKOFF_RETRIES
               value: "{{ .Values.app.authn.oidc.backoff_max_retries }}"


### PR DESCRIPTION
Add missing environment variable PERMIFY_AUTHN_OIDC_BACKOFF_FREQUENCY in deployment.

This currently causes a deployment with OIDC authentication to fail due to missing backoff frequency, as there is no default value set, as documented in https://docs.permify.co/setting-up/configuration#authn-server-authentication