### PR TITLE
fix: labels version refer to image version

### DIFF
--- a/charts/permify/Chart.yaml
+++ b/charts/permify/Chart.yaml
@@ -17,7 +17,7 @@ description: Helm charts for deploying and managing Permify in Kubernetes enviro
 type: application
 
 # The version of the Helm chart.
-version: 0.3.9
+version: 0.3.10
 
 # The specific application version that this Helm chart is designed to deploy.
 appVersion: "v1.1.3"

--- a/charts/permify/templates/_helpers.tpl
+++ b/charts/permify/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "permify.chart" . }}
 {{ include "permify.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ printf "v%s" .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
Hey, quick fix for kubernetes labels.
When specifying an image tags, the kubernetes version labels isn't referring the running image tags and lead to misunderstanding.

I propose to update the labels value with the same logic as image tag to get corresponding values.

Thanks for this awesome project!