### PR TITLE
enable adding deployment sidecars from helm chart values

### DIFF
--- a/charts/permify/templates/deployment.yaml
+++ b/charts/permify/templates/deployment.yaml
@@ -455,6 +455,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.deployment.sidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
 
       {{- with .Values.extraVolumes }}
       volumes:

--- a/charts/permify/values.yaml
+++ b/charts/permify/values.yaml
@@ -167,3 +167,7 @@ autoscaling:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Structure this deployment.sidecar value as if you were adding the container
+# to the Deployment's spec.template.spec.containers key.
+sidecars: []


### PR DESCRIPTION
We would like to deploy a sidecar, [GCP's SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy), with the permify deployment. Here's a change to allow adding sidecars to the deployment via the chart's values.

There should be no differences for users upgrading; a user has to explicitly add a valid container spec to a new value that will be empty by default.