### PR TITLE
fix: support image.digest and keep app.kubernetes.io/version a valid label

### DIFF
--- a/charts/permify/Chart.yaml
+++ b/charts/permify/Chart.yaml
@@ -17,7 +17,7 @@ description: Helm charts for deploying and managing Permify in Kubernetes enviro
 type: application
 
 # The version of the Helm chart.
-version: 0.5.0
+version: 0.5.1
 
 # The specific application version that this Helm chart is designed to deploy.
 appVersion: "v1.3.5"

--- a/charts/permify/templates/_helpers.tpl
+++ b/charts/permify/templates/_helpers.tpl
@@ -36,8 +36,8 @@ Common labels
 {{- define "permify.labels" -}}
 helm.sh/chart: {{ include "permify.chart" . }}
 {{ include "permify.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ printf "v%s" .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- with (include "permify.versionLabel" .) }}
+app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
@@ -59,4 +59,29 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Container image reference. A digest pins the image immutably and replaces the tag,
+mirroring OCI reference semantics.
+*/}}
+{{- define "permify.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository (.Values.image.digest | toString) -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion | toString) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Value for the app.kubernetes.io/version label. Kubernetes label values are limited to
+63 characters and must match [A-Za-z0-9]([-_.A-Za-z0-9]*[A-Za-z0-9])?, so an image
+digest can never be used verbatim. Prefer the tag, strip any inline digest, and omit
+the label entirely if nothing valid remains.
+*/}}
+{{- define "permify.versionLabel" -}}
+{{- $version := .Values.image.tag | default .Chart.AppVersion | toString | splitList "@" | first | trunc 63 | trimAll "-_." -}}
+{{- if regexMatch "^[A-Za-z0-9]([-_.A-Za-z0-9]*[A-Za-z0-9])?$" $version -}}
+{{- $version -}}
+{{- end -}}
 {{- end }}

--- a/charts/permify/templates/deployment.yaml
+++ b/charts/permify/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "permify.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["serve"]
           ports:

--- a/charts/permify/templates/tests/test-connection.yaml
+++ b/charts/permify/templates/tests/test-connection.yaml
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   containers:
     - name: grpc-health-probe
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: {{ include "permify.image" . | quote }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command: ["grpc_health_probe", '-addr={{ include "permify.fullname" . }}:{{ .Values.app.server.grpc.port }}']
   restartPolicy: Never

--- a/charts/permify/values.schema.json
+++ b/charts/permify/values.schema.json
@@ -238,6 +238,9 @@
         "image": {
             "type": "object",
             "properties": {
+                "digest": {
+                    "type": "string"
+                },
                 "pullPolicy": {
                     "type": "string"
                 },

--- a/charts/permify/values.yaml
+++ b/charts/permify/values.yaml
@@ -4,6 +4,8 @@ image:
   repository: ghcr.io/permify/permify
   pullPolicy: Always
   tag: ""
+  # -- Image digest (sha256:...). Takes precedence over tag when set.
+  digest: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Digest-pinned images currently break the chart: the version label is built from image.tag, so a tag carrying @sha256:... renders an 88-character label containing @ and : and the API server rejects every object that includes permify.labels. The same expression also double-prefixes v (vv1.6.10) and has a dead .Chart.AppVersion fallback that renders a bare "v" on default values.

Adds an image.digest value so digests replace the tag in the rendered image reference (permify.image), and derives the version label through a new permify.versionLabel helper that strips any inline digest, truncates to 63 characters, and validates against the Kubernetes label grammar before emitting it - falling back to .Chart.AppVersion, or omitting the label entirely, otherwise. No v prefix is prepended to user-provided tags.

Verified with `helm template` across defaults, tag-only, tag+digest, digest-only, and legacy tag@digest values; every rendered app.kubernetes.io/version matches ^[A-Za-z0-9]([-_.A-Za-z0-9]*[A-Za-z0-9])?$ and stays under 63 characters, and `helm lint` passes.